### PR TITLE
Citizen view polish and analytics explainers

### DIFF
--- a/frontend/src/app/pages/CitizenViewPage.tsx
+++ b/frontend/src/app/pages/CitizenViewPage.tsx
@@ -1,22 +1,15 @@
 import { useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
-import { AlertCircle, ArrowRight, CheckCircle2, Shield, ChevronLeft } from "lucide-react";
+import { AlertCircle, CheckCircle2, Shield, ChevronLeft } from "lucide-react";
 import { fetchAnalysis, pollJobStatus } from "../../services/api";
 import type { ForensicReport } from "../../services/adapter";
 import { Button } from "../components/ui/button";
 
 const LAST_JOB_ID_STORAGE_KEY = "mendacia:lastJobId";
+const LAST_FILENAME_STORAGE_KEY = "mendacia:lastFilename";
 
 function clamp(value: number, min = 0, max = 100): number {
   return Math.min(max, Math.max(min, value));
-}
-
-function formatLabel(label: string): string {
-  return label
-    .split(/[^a-zA-Z0-9]+/g)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
 }
 
 type ScoreTone = {
@@ -173,7 +166,6 @@ export function CitizenViewPage() {
   const scoreColor = scoreTone.text;
   const gaugeNeedleScore = clamp(confidenceScore);
   const credibilityScore = clamp(100 - confidenceScore);
-  const formattedClassification = formatLabel(report?.classification.label ?? "Unknown");
   const categories = report?.manipulation.categories ?? [];
   const flags = report?.anomalies ?? [];
   const synthesisScore = useMemo(() => {
@@ -200,6 +192,25 @@ export function CitizenViewPage() {
   }, [confidenceScore, flags.length, report]);
 
   const reportText = report?.human_readable_report?.trim() || "No human-readable report available.";
+  const videoFilename = useMemo(() => {
+    const candidate = report?.metadata.filename?.trim();
+    if (candidate && candidate !== "Unknown Video") {
+      return candidate;
+    }
+    if (typeof window !== "undefined") {
+      const jobFilename = activeJobId
+        ? window.localStorage.getItem(`mendacia:jobFilename:${activeJobId}`)
+        : null;
+      if (jobFilename) {
+        return jobFilename;
+      }
+      const lastFilename = window.localStorage.getItem(LAST_FILENAME_STORAGE_KEY);
+      if (lastFilename) {
+        return lastFilename;
+      }
+    }
+    return report?.metadata.video_id || "No report loaded";
+  }, [activeJobId, report?.metadata.filename, report?.metadata.video_id]);
   const forensicPath = activeJobId ? `/forensic-lab?jobId=${encodeURIComponent(activeJobId)}` : "/forensic-lab";
 
   return (
@@ -230,13 +241,6 @@ export function CitizenViewPage() {
                 </div>
               </div>
             </div>
-            <Button
-              onClick={() => navigate(forensicPath)}
-              className="bg-[#22d3ee]/10 hover:bg-[#22d3ee]/20 text-[#22d3ee] border border-[#22d3ee]/30"
-            >
-              View Detailed Analytics
-              <ArrowRight className="h-4 w-4 ml-2" />
-            </Button>
           </div>
         </div>
       </header>
@@ -265,11 +269,10 @@ export function CitizenViewPage() {
           <div className="text-center mb-12">
             <div className="inline-block bg-[#1e293b]/50 backdrop-blur-sm border border-slate-700/50 rounded-lg px-6 py-3 mb-4">
               <p className="text-sm text-slate-400 font-mono">
-                {report?.metadata.filename || report?.metadata.video_id || "No report loaded"}
+                {videoFilename}
               </p>
             </div>
             <h2 className="text-3xl font-bold text-white mb-2">Media Safety Analysis</h2>
-            <p className="text-slate-400">Simple breakdown for everyone</p>
           </div>
 
           {/* Trust Gauge - The Hero Element */}

--- a/frontend/src/app/pages/ForensicLabPage.tsx
+++ b/frontend/src/app/pages/ForensicLabPage.tsx
@@ -267,6 +267,7 @@ export function ForensicLabPage() {
   const [isLoadingReport, setIsLoadingReport] = useState(false);
   const [statusText, setStatusText] = useState("");
   const [errorText, setErrorText] = useState<string | null>(null);
+  const [activeMetric, setActiveMetric] = useState<string | null>(null);
 
   useEffect(() => {
     if (!jobId || typeof window === "undefined") {
@@ -581,6 +582,24 @@ export function ForensicLabPage() {
     doc.save(`${payload.video_id || "forensic-report"}-report.pdf`);
   };
 
+  const metricDetails: Record<string, { title: string; description: string }> = {
+    manipulation: {
+      title: "Manipulation %",
+      description:
+        "Derived from the backend confidence score. It blends inconsistency severity, category count, and rationale confidence to estimate manipulation likelihood.",
+    },
+    credibility: {
+      title: "Credibility %",
+      description:
+        "Computed as 100 - manipulation score. Higher credibility indicates fewer manipulation signals detected in this report.",
+    },
+    synthesis: {
+      title: "Synthesis Score",
+      description:
+        "Aggregated signal strength across category magnitudes and anomaly severity. It summarizes how strong and consistent the detected signals are.",
+    },
+  };
+
   return (
     <div className="min-h-screen bg-[#020617] relative overflow-hidden">
       {/* Grid Background */}
@@ -662,6 +681,9 @@ export function ForensicLabPage() {
                     color: "#e2e8f0",
                     fontFamily: "monospace",
                   }}
+                  labelStyle={{ color: "#e2e8f0" }}
+                  itemStyle={{ color: "#e2e8f0" }}
+                  formatter={(value) => [`${value}%`, "Magnitude"]}
                 />
                 <Bar dataKey="magnitude" radius={[6, 6, 0, 0]}>
                   {categoryMagnitudeData.map((entry) => (
@@ -672,16 +694,27 @@ export function ForensicLabPage() {
             </ResponsiveContainer>
             <div className="grid grid-cols-3 gap-3 mt-4">
               {[
-                { label: "Manipulation %", value: manipulationScore, color: verdictTone.text },
-                { label: "Credibility %", value: credibilityScore, color: "text-cyan-300" },
-                { label: "Synthesis Score", value: synthesisScore, color: "text-purple-300" },
+                { key: "manipulation", label: "Manipulation %", value: manipulationScore, color: verdictTone.text },
+                { key: "credibility", label: "Credibility %", value: credibilityScore, color: "text-cyan-300" },
+                { key: "synthesis", label: "Synthesis Score", value: synthesisScore, color: "text-purple-300" },
               ].map((item) => (
-                <div key={item.label} className="bg-slate-800/50 rounded-lg p-3 text-center">
+                <button
+                  key={item.key}
+                  type="button"
+                  onClick={() => setActiveMetric((prev) => (prev === item.key ? null : item.key))}
+                  className="bg-slate-800/50 rounded-lg p-3 text-center border border-transparent hover:border-slate-500/60 hover:bg-slate-800/70 transition-colors"
+                >
                   <div className={`text-2xl font-bold mb-1 ${item.color}`}>{Math.round(item.value)}%</div>
                   <div className="text-xs text-slate-400 font-mono">{item.label}</div>
-                </div>
+                </button>
               ))}
             </div>
+            {activeMetric ? (
+              <div className="mt-4 rounded-xl border border-slate-700/60 bg-[#0f172a]/70 p-4">
+                <p className="text-sm text-slate-200 font-semibold mb-1">{metricDetails[activeMetric].title}</p>
+                <p className="text-xs text-slate-400 leading-relaxed">{metricDetails[activeMetric].description}</p>
+              </div>
+            ) : null}
           </div>
 
           {/* Manipulation Taxonomy */}

--- a/frontend/src/app/pages/HomePage.tsx
+++ b/frontend/src/app/pages/HomePage.tsx
@@ -27,6 +27,8 @@ export function HomePage() {
       const { job_id } = await uploadVideo(file);
       if (typeof window !== "undefined") {
         window.localStorage.setItem("mendacia:lastJobId", job_id);
+        window.localStorage.setItem(`mendacia:jobFilename:${job_id}`, file.name);
+        window.localStorage.setItem("mendacia:lastFilename", file.name);
       }
       navigate(`/citizen-view?jobId=${encodeURIComponent(job_id)}`);
     } catch (error) {


### PR DESCRIPTION
- Show uploaded filename on citizen report (fallback to last known filename).
- Remove redundant top-right “View Detailed Analytics” button.
- Remove “Simple breakdown for everyone” subtext.
- Improve chart tooltip contrast (Magnitude text).
- Make manipulation/credibility/synthesis blocks clickable with explanatory copy.